### PR TITLE
Corrects name of package in pyproject.toml

### DIFF
--- a/impc_api_helper/pyproject.toml
+++ b/impc_api_helper/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "impc-_api_helper"
+name = "impc_api_helper"
 version = "0.1.0"
 description = "A package to facilitate making API requests to the IMPC Solr API"
 authors = [


### PR DESCRIPTION
Corrected a typo in the package name in `pyproject.toml`. Upon installation users would have seen a message like:
`installed impc-_api_helper`. Removed the hyphen. 