### PR TITLE
Replace outdated URLs

### DIFF
--- a/impc_api_helper/pyproject.toml
+++ b/impc_api_helper/pyproject.toml
@@ -20,7 +20,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 
 [project.urls]
-"Homepage" = "https://github.com/marinak-ebi/impc-workshop"
+"Homepage" = "https://github.com/mpi2/impc-data-api-workshop"
 
 [tool.setuptools]
 packages = ["impc_api_helper"]

--- a/impc_api_helper/setup.py
+++ b/impc_api_helper/setup.py
@@ -5,7 +5,7 @@ setup(
     version='0.1.0',
     description='A package to facilitate making API request to the IMPC Solr API',
     author='MPI2, Marina Kan, Diego Pava',
-    url='https://github.com/marinak-ebi/impc-workshop',
+    url='https://github.com/mpi2/impc-data-api-workshop',
     packages=find_packages(),
     install_requires=[
         'pandas>=2.2.0',


### PR DESCRIPTION
Substitute link to the previous repository `marinak-ebi/impc-workshop` with the current one: `mpi2/impc-data-api-workshop`