### PR TITLE
Add documentation to faceting query parameters and stylise comments

### DIFF
--- a/impc_api_helper/README.md
+++ b/impc_api_helper/README.md
@@ -1,7 +1,5 @@
-# IMPC-API-HELPER
-Name is a work in progress, we can think of something nicer
-
-README for draft impc-api python package.
+# IMPC_API_HELPER
+README for draft `impc_api_helper` python package.
 
 The functions in this package are intended for use on a Jupyter Notebook.
 

--- a/impc_api_helper/impc_api_helper/iterator_solr_request.py
+++ b/impc_api_helper/impc_api_helper/iterator_solr_request.py
@@ -1,6 +1,7 @@
-import json
-import requests
 import csv
+import json
+
+import requests
 
 
 # Helper function to fetch results. This function is used by the 'iterator_solr_request' function.
@@ -53,36 +54,35 @@ def iterator_solr_request(
     core, params, filename="iteration_solr_request", format="json"
 ):
     """Function to fetch results in batches from the Solr API and write them to a file.
-            Defaults to fetching 5000 rows at a time.
+    Defaults to fetching 5000 rows at a time.
+    Avoids cluttering local memory, ideal for large requests.
+    
+    Args:
+        core (str): The name of the Solr core to fetch results from.
+        params (dict): A dictionary of parameters to use in the filter query. Must include
+                       'field_list' and 'field_type' keys, which represent the list of field items (i.e., list of MGI model identifiers)
+                        to fetch and the type of the field (i.e., model_id) to filter on, respectively.
+        filename (str): The name of the file/path to write the results to. Defaults to 'iteration_solr_request'.
+        format (str): The format of the output file. Can be 'csv' or 'json'. Defaults to 'json'.
 
-        Avoids cluttering local memory, ideal for large requests.
+    Returns: None
 
     Example use case:
-    # List of model IDs.
-    models = ["MGI:3587188","MGI:3587185","MGI:3605874","MGI:2668213"]
+        # List of model IDs.
+        models = ['MGI:3587188', 'MGI:3587185', 'MGI:3605874', 'MGI:2668213']
 
-    # Call iterator function
-    iterator_solr_request(
-        core='phenodigm',
+        # Call iterator function
+        iterator_solr_request(
+            core='phenodigm',
             params = {
-            'q': 'type:disease_model_summary',
-            'fl': 'model_id,marker_id,disease_id',
-            'field_list': models,
-            'field_type': 'model_id'
-        },
-        filename='model_ids',
-        format='csv')
-
-        Args:
-            core (str): The name of the Solr core to fetch results from.
-            params (dict): A dictionary of parameters to use in the filter query. Must include
-                           'field_list' and 'field_type' keys, which represent the list of field items (i.e., list of MGI model identifiers)
-                            to fetch and the type of the field (i.e., model_id) to filter on, respectively.
-            filename (str): The name of the file/path to write the results to. Defaults to 'iteration_solr_request'.
-            format (str): The format of the output file. Can be 'csv' or 'json'. Defaults to 'json'.
-
-        Returns: None
-        
+                'q': 'type:disease_model_summary',
+                'fl': 'model_id,marker_id,disease_id',
+                'field_list': models,
+                'field_type': 'model_id'
+            },
+            filename='model_ids',
+            format='csv'
+        )
     """
 
     # Validate format

--- a/impc_api_helper/impc_api_helper/solr_request.py
+++ b/impc_api_helper/impc_api_helper/solr_request.py
@@ -28,37 +28,37 @@ def solr_request(core, params, silent=False):
 
     Example query:
         num_found, df = solr_request(
-        core='genotype-phenotype',
-        params={
-            'q': '*:*',  # Your query, '*' retrieves all documents.
-            'rows': 10,  # Number of rows to retrieve.
-            'fl': 'marker_symbol,allele_symbol,parameter_stable_id',  # Fields to retrieve.
-        }
-    )
+            core='genotype-phenotype',
+            params={
+                'q': '*:*',  # Your query, '*' retrieves all documents.
+                'rows': 10,  # Number of rows to retrieve.
+                'fl': 'marker_symbol,allele_symbol,parameter_stable_id',  # Fields to retrieve.
+            }
+        )
     
     Faceting query provides a summary of data distribution across the specified fields.
     Example faceting query:
         num_found, df = solr_request(
-        core='genotype-phenotype',
-        params={
-            'q': '*:*',  # Your query, '*' retrieves all documents.
-            'rows': 0,  # Number of rows to retrieve.
-            'facet': 'on',  # Enable facet counts in query response.
-            'facet.field': 'zygosity',  # Identifies a field to be treated as a facet.
-            'facet.limit': 15,  # Controls how many constraints should be returned for each facet.
-            'facet.mincount': 1  # Specifies the minimum counts required be included in response.
-        }
-    )
+            core='genotype-phenotype',
+            params={
+                'q': '*:*',  # Your query, '*' retrieves all documents.
+                'rows': 0,  # Number of rows to retrieve.
+                'facet': 'on',  # Enable facet counts in query response.
+                'facet.field': 'zygosity',  # Identifies a field to be treated as a facet.
+                'facet.limit': 15,  # Controls how many constraints should be returned for each facet.
+                'facet.mincount': 1  # Specifies the minimum counts required be included in response.
+            }
+        )
 
     When querying the phenodigm core, pass 'q': 'type:...'
     Example phenodigm query: 
         num_found, df = solr_request(
-        core='phenodigm',
-        params={
-            'q': 'type:disease_model_summary',  # Pass the type within the core and filters.
-            'rows': 5
-        }
-    )
+            core='phenodigm',
+            params={
+                'q': 'type:disease_model_summary',  # Pass the type within the core and filters.
+                'rows': 5
+            }
+        )
     """
 
     base_url = "https://www.ebi.ac.uk/mi/impc/solr/"

--- a/impc_api_helper/impc_api_helper/solr_request.py
+++ b/impc_api_helper/impc_api_helper/solr_request.py
@@ -13,14 +13,26 @@ pd.set_option("display.max_columns", None)
 # Create helper function
 def solr_request(core, params, silent=False):
     """Performs a single Solr request to the IMPC Solr API.
+    
+    Args:
+        core (str): name of IMPC solr core.
+        params (dict): dictionary containing the API call parameters.
+        silent (bool, optional): default False
+            If True, displays: URL of API call, the number of found docs 
+            and a portion of the DataFrame. 
+
+
+    Returns:
+        num_found: Number of docs found.
+        pandas.DataFrame: Pandas.DataFrame object with the information requested.
 
     Example query:
         num_found, df = solr_request(
         core='genotype-phenotype',
         params={
-            'q': '*:*',  # Your query, '*' retrieves all documents
-            'rows': 10,  # Number of rows to retrieve
-            'fl': 'marker_symbol,allele_symbol,parameter_stable_id',  # Fields to retrieve
+            'q': '*:*',  # Your query, '*' retrieves all documents.
+            'rows': 10,  # Number of rows to retrieve.
+            'fl': 'marker_symbol,allele_symbol,parameter_stable_id',  # Fields to retrieve.
         }
     )
     
@@ -29,12 +41,12 @@ def solr_request(core, params, silent=False):
         num_found, df = solr_request(
         core='genotype-phenotype',
         params={
-            'q': '*:*',
-            'rows': 0,
-            'facet': 'on',
-            'facet.field': 'zygosity',
-            'facet.limit': 15,
-            'facet.mincount': 1
+            'q': '*:*',  # Your query, '*' retrieves all documents.
+            'rows': 0,  # Number of rows to retrieve.
+            'facet': 'on',  # Enable facet counts in query response.
+            'facet.field': 'zygosity',  # Identifies a field to be treated as a facet.
+            'facet.limit': 15,  # Controls how many constraints should be returned for each facet.
+            'facet.mincount': 1  # Specifies the minimum counts required be included in response.
         }
     )
 
@@ -43,20 +55,10 @@ def solr_request(core, params, silent=False):
         num_found, df = solr_request(
         core='phenodigm',
         params={
-            'q': 'type:disease_model_summary', # Pass the type within the core and filters.
+            'q': 'type:disease_model_summary',  # Pass the type within the core and filters.
             'rows': 5
         }
     )
-
-    Args:
-        core (str): name of IMPC solr core.
-        params (dict): dictionary containing the API call parameters.
-        silent (bool, optional): When True, displays: URL of API call, the number of found docs and a portion of the DataFrame. Defaults to False.
-
-
-    Returns:
-        num_found: Number of docs found.
-        pandas.DataFrame: Pandas.DataFrame object with the information requested.
     """
 
     base_url = "https://www.ebi.ac.uk/mi/impc/solr/"
@@ -66,44 +68,44 @@ def solr_request(core, params, silent=False):
     if not silent:
         print(f"\nYour request:\n{response.request.url}\n")
 
-    # Check if the request was successful (status code 200)
+    # Check if the request was successful (status code 200).
     if response.status_code == 200:
-        # Parse the JSON response
+        # Parse the JSON response.
         data = response.json()
         num_found = data["response"]["numFound"]
         if not silent:
             print(f"Number of found documents: {num_found}\n")
 
-        # For faceting query
+        # For faceting query.
         if params.get('facet') == 'on':
-            # Extract and add faceting query results to the list
+            # Extract and add faceting query results to the list.
             facet_counts = data["facet_counts"]["facet_fields"][params["facet.field"]]
-            # Initialize an empty dictionary
+            # Initialize an empty dictionary.
             faceting_dict = {}
-            # Iterate over the list, taking pairs of elements
+            # Iterate over the list, taking pairs of elements.
             for i in range(0, len(facet_counts), 2):
-                # Assign label as key and count as value
+                # Assign label as key and count as value.
                 label = facet_counts[i]
                 count = facet_counts[i + 1]
                 faceting_dict[label] = [count]
 
-            # Convert the list of dictionaries into a DataFrame and print the DataFrame
+            # Convert the list of dictionaries into a DataFrame and print the DataFrame.
             df = pd.DataFrame.from_dict(
                     faceting_dict, orient="index", columns=["counts"]
                 ).reset_index()
-            # Rename the columns
+            # Rename the columns.
             df.columns = [params["facet.field"], "count_per_category"]
 
-        # For regular query
+        # For regular query.
         else:
-            # Extract and add search results to the list
+            # Extract and add search results to the list.
             search_results = []
             for doc in data["response"]["docs"]:
                 search_results.append(doc)
-    
-            # Convert the list of dictionaries into a DataFrame and print the DataFrame
+
+            # Convert the list of dictionaries into a DataFrame and print the DataFrame.
             df = pd.DataFrame(search_results)
-        
+
         if not silent:
             display(df)
         return num_found, df
@@ -114,9 +116,18 @@ def solr_request(core, params, silent=False):
 
 # Batch request based on solr_request
 def batch_request(core, params, batch_size):
-    """Calls `solr_request` multiple times with `params` to retrieve results in chunk `batch_size` rows at a time.
+    """Calls `solr_request` multiple times with `params`
+    to retrieve results in chunk `batch_size` rows at a time.
 
     Passing parameter `rows` is ignored and replaced with `batch_size`
+   
+   Args:
+        core (str): name of IMPC solr core.
+        params (dict): dictionary containing the API call parameters.
+        batch_size (int): Size of batches (number of docs) per request.
+
+    Returns:
+        pandas.DataFrame: Pandas.DataFrame object with the information requested.
 
     Example query:
         df = batch_request(
@@ -125,15 +136,8 @@ def batch_request(core, params, batch_size):
                 'q': 'top_level_mp_term_name:"cardiovascular system phenotype" AND effect_size:[* TO *] AND life_stage_name:"Late adult"',
                 'fl': 'allele_accession_id,life_stage_name,marker_symbol,mp_term_name,p_value,parameter_name,parameter_stable_id,phenotyping_center,statistical_method,top_level_mp_term_name,effect_size'
             },
-            batch_size=100)
-
-    Args:
-        core (str): name of IMPC solr core.
-        params (dict): dictionary containing the API call parameters.
-        batch_size (int): Size of batches (number of docs) per request.
-
-    Returns:
-        pandas.DataFrame: Pandas.DataFrame object with the information requested.
+            batch_size=100
+        )
     """
 
     if "rows" in "params":


### PR DESCRIPTION
1. Replace hyphens with underscores in the name of module, so pip and import name match. 
2. Closes #2 
3. Add dot in the end of comments.
4. Fix indentation in the example queries. 
5. Swap examples and args in the comment section.